### PR TITLE
Add support for NVHPC compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ adcpost
 adcprep
 dgswem
 dgswem_serial
+tests

--- a/metis/Lib/minitpart.c
+++ b/metis/Lib/minitpart.c
@@ -9,11 +9,13 @@
  * Started 7/23/97
  * George
  *
- * $Id: minitpart.c,v 1.2 1998/11/30 15:08:37 karypis Exp $
+ * $Id: minitpart.c,v 1.1.1.1 2003/01/23 17:21:06 estrade Exp $
  *
  */
 
-#include <metis.h>
+#include "metis.h"
+
+int SelectQueueOneWay(int ncon, float *npwgts, float *tpwgts, int from, PQueueType queues[MAXNCON][2]);
 
 /*************************************************************************
 * This function computes the initial bisection of the coarsest graph

--- a/metis/Lib/proto.h
+++ b/metis/Lib/proto.h
@@ -8,7 +8,7 @@
  * Started 10/19/95
  * George
  *
- * $Id: proto.h,v 1.1 1998/11/27 17:59:28 karypis Exp $
+ * $Id: proto.h,v 1.1.1.1 2003/01/23 17:21:06 estrade Exp $
  *
  */
 
@@ -432,7 +432,7 @@ int *ismalloc(int, int, char *);
 idxtype *idxsmalloc(int, idxtype, char *);
 void *GKmalloc(int, char *);
 #endif
-/*void GKfree(void **,...); */
+void GKfree(void **,...);
 int *iset(int n, int val, int *x);
 idxtype *idxset(int n, idxtype val, idxtype *x);
 float *sset(int n, float val, float *x);

--- a/metis/Lib/rename.h
+++ b/metis/Lib/rename.h
@@ -410,9 +410,4 @@
 #define RandomPermute			__RandomPermute
 #define ispow2				__ispow2
 #define InitRandom			__InitRandom
-#define log2				__log2
-
-
-
-
-
+#define log2				__mlog2

--- a/src/DG_hydro_timestep.F
+++ b/src/DG_hydro_timestep.F
@@ -201,7 +201,7 @@ C.......For non-periodic flux bcs
 
 C.......Compute LDG auxiliary equations
          
-         IF (EVMSUM.NE.0.D0.or.artdif.eq.1) CALL LDG_HYDRO(IT)
+         IF (artdif.eq.1) CALL LDG_HYDRO(IT)
          
 C.......Compute elevation specified edges
 

--- a/src/calc_normal.F
+++ b/src/calc_normal.F
@@ -14,14 +14,14 @@ C***********************************************************************
 
 C.....Use appropriate modules
 
-      USE GLOBAL
-      USE DG
+      USE GLOBAL, only : x, y, sfac
+      USE DG, only : xlen, cosnx, sinnx, nedges, nedno,  sav
       
       IMPLICIT NONE
       
 C.....Declare local variables
 
-      INTEGER IEL, IED,i
+      INTEGER IEL, IED,i, n1, n2
 
 C.....Loop over the edges
 

--- a/work/cmplrflags.mk
+++ b/work/cmplrflags.mk
@@ -286,12 +286,13 @@ endif
 ########################################################################
 # Compiler flags for Linux operating system on 64bit x86 CPU
 #
-ifneq (,$(findstring x86_64-linux-gnu,$(MACHINE)-$(OS)))
+ifneq (,$(findstring linux-gnu,$(OS)))
 #
 # ***NOTE*** User must select between various Linux setups
 #            by commenting/uncommenting the appropriate compiler
 #
 compiler=intel-lonestar
+#compiler=nvhpc
 #compiler=cray_xt3
 #compiler=kraken
 #
@@ -323,7 +324,7 @@ ifeq ($(compiler),intel-lonestar)
   PPFC          :=  ifort	
   FC            :=  ifort
   PFC           :=  mpif90
-  CC            :=  icc
+  CC            :=  icx
   FFLAGS1       :=  $(INCDIRS) -O2 -msse3 -132  #-traceback -check all #-prof-gen -prof-dir /bevo2/michoski/v21/work -pg -prof-use
   FFLAGS2       :=  $(FFLAGS1)
   FFLAGS3       :=  $(FFLAGS1)
@@ -332,10 +333,29 @@ ifeq ($(compiler),intel-lonestar)
   DP            :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DRKSSP -DSLOPE5 #-DDGOUT #-DOUT_TEC #-DARTDIF #-DWETDR  # -DSED_LAY -DRKC -DTRACE -DSED_LAY -DCHEM -DP0 -DP_AD -DSLOPEALL
   DPRE          :=  -DREAL8 -DLINUX -DRKSSP -DSLOPE5 #-DOUT_TEC #-DSWAN #-DARTDIF  # -DWETDR #-DSED_LAY -DSWAN #-DOUT_TEC #-DSWAN -DRKC -DTRACE -DSED_LAY -DCHEM -DP0 -DP_AD -DSLOPEALL
   DPRE2         :=  -DREAL8 -DLINUX -DCMPI 
-  CFLAGS        :=  -O3 -xSSSE3 -I.
+  CFLAGS        :=  -O3 -xSSSE3 -I. -Wno-implicit-function-declaration
   IMODS         :=  -I
   LIBS          :=  -L ../metis -lmetis
   MSGLIBS       :=
 endif
 
+ifeq ($(compiler),nvhpc)   # NVIDIA
+  PPFC	        :=  nvfortran
+  FC	        :=  nvfortran
+  PFC	        :=  mpif90
+  FFLAGS1	:=  -Mextend -traceback -g -O3
+  FFLAGS2	:=  $(FFLAGS1)
+  FFLAGS3	:=  $(FFLAGS1)
+  FFLAGS4	:=  $(FFLAGS1)
+  DA  	        :=  -DREAL8 -DLINUX -DCSCA -DRKSSP -DSLOPE5
+  DP  	        :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DRKSSP -DSLOPE5
+  DPRE	        :=  -DREAL8 -DLINUX -DRKSSP -DSLOPE5
+  DPRE2         :=  -DREAL8 -DLINUX -DCMPI
+  IMODS 	:=  -I
+  CC            :=  nvc
+  CFLAGS        :=  -O3 -I. -fastsse -DLINUX
+  CLIBS         :=
+  LIBS  	:=  -L ../metis  -lmetis
+  MSGLIBS	:=
+endif
 endif

--- a/work/makefile
+++ b/work/makefile
@@ -1,7 +1,7 @@
 SHELL:=/bin/sh
 #
 #  Makefile to Build DGSWEM and its pre/post-processor
-export MPICH_FC=ifort
+#export MPICH_FC=ifort
 
 ########################################################################
 #  Get Canonical Machine NAME from config.guess
@@ -11,6 +11,9 @@ LIST     := $(subst -, ,$(NAME))
 MACHINE  := $(word 1, $(LIST))
 VENDOR   := $(word 2, $(LIST))
 OS       := $(subst  $(MACHINE)-$(VENDOR)-,,$(strip $(NAME)))
+
+$(info MACHINE is $(MACHINE))
+$(info OS is $(OS))
 
 include cmplrflags.mk
 #Casey 121126: Include variables/flags from SWAN.
@@ -37,7 +40,7 @@ endif
 ifeq ($(BUILDTYPE),dgswem_serial)
   CF:= $(PPFC)
   O_DIR:=odir4/
-  FFLAGS:= $(FFLAGS3) $(DA) $(IMODS)$(O_DIR) -g -p -traceback -fpe0
+  FFLAGS:= $(FFLAGS3) $(DA) $(IMODS)$(O_DIR)
   VPATH:=  ../src
   MSG_MOBJ:=
 endif
@@ -54,7 +57,7 @@ endif
 ifeq ($(BUILDTYPE),dgswem)
   CF:= $(PFC)
   O_DIR:=odir5/
-  FFLAGS:= $(FFLAGS4) $(DP) $(IMODS)$(O_DIR) -traceback -fpe0
+  FFLAGS:= $(FFLAGS4) $(DP) $(IMODS)$(O_DIR)
   VPATH :=  ../src
   MSG_MOBJ:= $(O_DIR)messenger_elem.o $(O_DIR)messenger.o
   MSG_OBJ:=


### PR DESCRIPTION
To use NVIDIA compilers, uncomment the line `compiler=nvhpc` in `cmplrflags.mk` .