### PR TITLE
fix: Several makefile issues

### DIFF
--- a/work/cmplrflags.mk
+++ b/work/cmplrflags.mk
@@ -29,9 +29,9 @@ endif
 ifeq ($(compiler),intel)
   PPFC          :=  ifx
   FC            :=  ifx
-  PFC           :=  mpif90
+  PFC           :=  mpiifx
   CC            :=  icx
-  FFLAGS1       :=  -r8 $(INCDIRS) -O2 -msse3 -132  #-traceback -check all #-prof-gen -prof-dir /bevo2/michoski/v21/work -pg -prof-use
+  FFLAGS1       :=  -r8 $(INCDIRS) -O3 -xHost -msse3 -132  #-traceback -check all #-prof-gen -prof-dir /bevo2/michoski/v21/work -pg -prof-use
   FFLAGS2       :=  $(FFLAGS1)
   FFLAGS3       :=  $(FFLAGS1)
   FFLAGS4       :=  $(FFLAGS1)
@@ -40,7 +40,7 @@ ifeq ($(compiler),intel)
   DPRE          :=  -DREAL8 -DLINUX -DRKSSP -DSLOPE5 #-DOUT_TEC #-DSWAN #-DARTDIF  # -DWETDR #-DSED_LAY -DSWAN #-DOUT_TEC #-DSWAN -DRKC -DTRACE -DSED_LAY -DCHEM -DP0 -DP_AD -DSLOPEALL
   DPRE2         :=  -DREAL8 -DLINUX -DCMPI 
   CFLAGS        :=  -O3 -xSSSE3 -I. -Wno-implicit-function-declaration
-  IMODS         :=  -I
+  IMODS         :=  -module
   LIBS          :=  -L ../metis -lmetis
   MSGLIBS       :=
 endif
@@ -50,7 +50,7 @@ ifeq ($(compiler),nvhpc)   # NVIDIA
   PPFC	        :=  nvfortran
   FC	        :=  nvfortran
   PFC	        :=  mpif90
-  FFLAGS1	:=  -r$(sz) -Mextend -traceback -g -O3
+  FFLAGS1	:=  -r$(sz) -Mextend -traceback -g -O3 -tp=native
   FFLAGS2	:=  $(FFLAGS1)
   FFLAGS3	:=  $(FFLAGS1)
   FFLAGS4	:=  $(FFLAGS1)
@@ -58,7 +58,7 @@ ifeq ($(compiler),nvhpc)   # NVIDIA
   DP  	        :=  -DREAL$(sz) -DLINUX -DCSCA -DCMPI -DRKSSP -DSLOPE5
   DPRE	        :=  -DREAL$(sz) -DLINUX -DRKSSP -DSLOPE5
   DPRE2         :=  -DREAL$(sz) -DLINUX -DCMPI
-  IMODS 	:=  -I
+  IMODS 	:=  -module
   CC            :=  nvc
   CXX    := nvc++
   CXXFLAGS := -O3 -g
@@ -110,8 +110,7 @@ ifeq ($(compiler),gnu)   # AMD
   DP  	        :=  -DREAL$(sz) -DLINUX -DCSCA -DCMPI -DRKSSP -DSLOPE5
   DPRE	        :=  -DREAL$(sz) -DLINUX -DRKSSP -DSLOPE5
   DPRE2         :=  -DREAL$(sz) -DLINUX -DCMPI
-  IMODS 	:=  -I
-  MODULES = -J
+  IMODS 	:=  -J
   CC            :=  gcc
   CXX    := g++
   CXXFLAGS := -O3 -g

--- a/work/makefile
+++ b/work/makefile
@@ -13,7 +13,7 @@ include ../swan/macros.inc
 ifeq ($(BUILDTYPE),adcprep)
   CF:= $(PPFC)
   O_DIR:=odir1/
-  FFLAGS:= $(FFLAGS1) $(DPRE) $(IMODS)$(O_DIR)
+  FFLAGS:= $(FFLAGS1) $(DPRE) $(IMODS) $(O_DIR)
   VPATH :=  ../prep
   PMSG_OBJ:=
 endif
@@ -21,14 +21,14 @@ endif
 ifeq ($(BUILDTYPE),adcpost)
   CF:= $(PPFC)
   O_DIR:=odir3/
-  FFLAGS:= $(FFLAGS1) $(DPRE) $(IMODS)$(O_DIR)
+  FFLAGS:= $(FFLAGS1) $(DPRE) $(IMODS) $(O_DIR)
   VPATH :=  ../prep
 endif
 #                                      adcirc
 ifeq ($(BUILDTYPE),dgswem_serial)
   CF:= $(PPFC)
   O_DIR:=odir4/
-  FFLAGS:= $(FFLAGS3) $(DA) $(IMODS)$(O_DIR)
+  FFLAGS:= $(FFLAGS3) $(DA) $(IMODS) $(O_DIR)
   VPATH:=  ../src
   MSG_MOBJ:=
 endif
@@ -45,7 +45,7 @@ endif
 ifeq ($(BUILDTYPE),dgswem)
   CF:= $(PFC)
   O_DIR:=odir5/
-  FFLAGS:= $(FFLAGS4) $(DP) $(IMODS)$(O_DIR)
+  FFLAGS:= $(FFLAGS4) $(DP) $(IMODS) $(O_DIR)
   VPATH :=  ../src
   MSG_MOBJ:= $(O_DIR)messenger_elem.o $(O_DIR)messenger.o
   MSG_OBJ:=
@@ -55,7 +55,7 @@ endif
 ifeq ($(BUILDTYPE),dgswemswan)
   CF:= $(PFC)
   O_DIR:=odir55/
-  FFLAGS:= $(FFLAGS4) -DSWAN $(DP) $(IMODS)$(O_DIR)
+  FFLAGS:= $(FFLAGS4) -DSWAN $(DP) $(IMODS) $(O_DIR)
   VPATH :=  ../src:../swan
   MSG_MOBJ:= $(O_DIR)messenger_elem.o $(O_DIR)messenger.o $(O_DIR)globalio.o
   MSG_OBJ:=
@@ -157,17 +157,17 @@ SWAN_OBJ:= $(patsubst %.f90, $(O_DIR)%.o, $(SWAN_OBJ) )
 $(O_DIR)%.o  : %.F
 #  @echo depend $<
 #  @echo target $@
-	$(CF) -c $(FFLAGS) -o $@  $< $(MODULES) $(O_DIR)
+	$(CF) -c $(FFLAGS) -o $@  $<
 
 #Casey 121126: Changed the f90 files to F90 extension to avoid conflict with SWAN.
 $(O_DIR)%.o  : %.F90
-	$(CF) -c $(FFLAGS) -o $@  $< $(MODULES) $(O_DIR)
+	$(CF) -c $(FFLAGS) -o $@  $<
 
 #Casey 121126: Added the following rules for the unstructured SWAN.
 $(O_DIR)%.o  : %.f
-	$(CF) -c $(FLAGS_OPT) $(FLAGS_MSC) $(FLAGS_SER) $(MODULES) $(O_DIR) -o $@  $< $(MODULES) $(O_DIR)
+	$(CF) -c $(FLAGS_OPT) $(FLAGS_MSC) $(FLAGS_SER) $(IMODS) $(O_DIR) -o $@
 $(O_DIR)%.o  : %.f90
-	$(CF) -c $(FLAGS_OPT) $(FLAGS_MSC) $(FLAGS_SER) $(MODULES) $(O_DIR) -o $@  $< $(MODULES) $(O_DIR)
+	$(CF) -c $(FLAGS_OPT) $(FLAGS_MSC) $(FLAGS_SER) $(IMODS) $(O_DIR) -o $@
 
 $(O_DIR)%.o  : %.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $<


### PR DESCRIPTION
- Use correct compiler (mpiifx) for compiler=intel option

- Specify odir* as destination for module files

- Now compiles to the native architecture