### PR TITLE
Fix compiler errors

### DIFF
--- a/src/vortex.F
+++ b/src/vortex.F
@@ -903,7 +903,7 @@ c$$$      v = vf
       ! case(3): 4 situations
       ! case(4): 5 situations                    
       !=================================================================
-      pure REAL(sz) FUNCTION spInterp(angle,dist,opt)
+      REAL(sz) FUNCTION spInterp(angle,dist,opt)
 !$acc routine
       REAL(sz), INTENT(IN) :: angle,dist  
       INTEGER, INTENT(IN)  :: opt

--- a/src/wind.F
+++ b/src/wind.F
@@ -124,7 +124,7 @@ C
       INTRINSIC :: ATAN2
       INTRINSIC :: MOD
       INTEGER   :: IS
-      LOGICAL   :: FoundSector
+      LOGICAL   :: FoundSector, FoundEye_local
       REAL(SZ)  :: Dir1
       REAL(SZ)  :: Dir2
       REAL(SZ)  :: Drag(3)
@@ -146,11 +146,11 @@ C.. Check whether we have previously found the eye.
          IF((EyeLatR(1).EQ.0.0).OR.(EyeLonR(1).EQ.0.0).OR.
      &      (EyeLatR(2).EQ.0.0).OR.(EyeLonR(2).EQ.0.0).OR.
      &      (EyeLatR(3).EQ.0.0).OR.(EyeLonR(3).EQ.0.0))THEN
-            FoundEye = .FALSE.
+            FoundEye_local = .FALSE.
          ENDIF
 C.. If the eye has not been found then apply Garratt.
          WindDrag = 0.001D0*(0.75D0+0.067D0*WindSpeed)
-         IF(.NOT.FoundEye)THEN
+         IF(.NOT.FoundEye_local)THEN
             FoundSector = .FALSE.
             Weight = 0.0
             IF(WindDrag.GT.WindDragLimit) WindDrag = WindDragLimit

--- a/work/cmplrflags.mk
+++ b/work/cmplrflags.mk
@@ -1,17 +1,16 @@
-# sb46.50.02 These flags work on the UT Austin Lonstar cluster.
-ifneq (,$(findstring ifx,$(FC)))
+ifneq (,$(findstring ifx,$(FC))) # Intel
   PPFC          :=  ifx
   PFC           :=  mpiifx
   CC            :=  icx
-  FFLAGS1       :=  -r8 $(INCDIRS) -O3 -xHost -msse3 -132  #-traceback -check all #-prof-gen -prof-dir /bevo2/michoski/v21/work -pg -prof-use
+  FFLAGS1       :=  -r8 $(INCDIRS) -O3 -xHost -132
   FFLAGS2       :=  $(FFLAGS1)
   FFLAGS3       :=  $(FFLAGS1)
   FFLAGS4       :=  $(FFLAGS1)
-  DA            :=  -DREAL8 -DLINUX -DCSCA -DRKSSP -DSLOPE5 #-DDGOUT #-DOUT_TEC #-DARTDIF  #  -DWETDR # -DSED_LAY -DOUT_TEC #-DRKC -DTRACE -DSED_LAY -DCHEM -DP0 -DP_AD -DSLOPEALL -DFILTER
-  DP            :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DRKSSP -DSLOPE5 #-DDGOUT #-DOUT_TEC #-DARTDIF #-DWETDR  # -DSED_LAY -DRKC -DTRACE -DSED_LAY -DCHEM -DP0 -DP_AD -DSLOPEALL
-  DPRE          :=  -DREAL8 -DLINUX -DRKSSP -DSLOPE5 #-DOUT_TEC #-DSWAN #-DARTDIF  # -DWETDR #-DSED_LAY -DSWAN #-DOUT_TEC #-DSWAN -DRKC -DTRACE -DSED_LAY -DCHEM -DP0 -DP_AD -DSLOPEALL
+  DA            :=  -DREAL8 -DLINUX -DCSCA -DRKSSP -DSLOPE5
+  DP            :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DRKSSP -DSLOPE5
+  DPRE          :=  -DREAL8 -DLINUX -DRKSSP -DSLOPE5
   DPRE2         :=  -DREAL8 -DLINUX -DCMPI 
-  CFLAGS        :=  -O3 -xSSSE3 -I. -Wno-implicit-function-declaration
+  CFLAGS        :=  -O3 -I. -Wno-implicit-function-declaration
   IMODS         :=  -module
   LIBS          :=  -L ../metis -lmetis
   MSGLIBS       :=
@@ -20,11 +19,11 @@ else ifneq (,$(findstring nvfortran,$(FC)))   # NVIDIA
   sz            := 8
   PPFC	        :=  nvfortran
   PFC	        :=  mpif90
-ifeq ($(gpu),1)
-  FFLAGS1	:=  -r$(sz) -Mextend -Mlarge_arrays -cuda -traceback -g -O3 -acc -gpu=unified,lineinfo -Minfo=accel
-else
-  FFLAGS1	:=  -r$(sz) -Mextend -traceback -g -O3 -tp=native
-endif
+  ifeq ($(gpu),1)
+    FFLAGS1	:=  -r$(sz) -Mextend -Mlarge_arrays -cuda -traceback -g -O3 -acc -gpu=unified,lineinfo -Minfo=accel
+  else
+    FFLAGS1	:=  -r$(sz) -Mextend -traceback -g -O3 -tp=native
+  endif
   FFLAGS2	:=  $(FFLAGS1)
   FFLAGS3	:=  $(FFLAGS1)
   FFLAGS4	:=  $(FFLAGS1)
@@ -36,11 +35,11 @@ endif
   CC            :=  nvc
   CXX    := nvc++
   CXXFLAGS := -O3 -g
-  CFLAGS        :=  -O3 -I. -fastsse -DLINUX
+  CFLAGS        :=  -O3 -I. -DLINUX
   LIBS  	:=  -L ../metis  -lmetis
   MSGLIBS	:=
 
-else
+else  # GCC
   sz            := 8
   ifeq ($(sz),8)
     RFLAG = -fdefault-real-8 -fdefault-double-8
@@ -49,7 +48,7 @@ else
   endif
   PPFC	        :=  gfortran
   PFC	        :=  mpif90
-  FFLAGS1	:= $(RFLAG) -g -O3 -march=native -ffixed-line-length-132 -std=legacy -fallow-argument-mismatch
+  FFLAGS1	:= $(RFLAG) -g -O3 -march=native -ffixed-line-length-132 -std=legacy -fallow-argument-mismatch -lz
   FFLAGS2	:=  $(FFLAGS1)
   FFLAGS3	:=  $(FFLAGS1)
   FFLAGS4	:=  $(FFLAGS1)
@@ -61,7 +60,7 @@ else
   CC            :=  gcc
   CXX    := g++
   CXXFLAGS := -O3 -g
-  CFLAGS        :=  -O3 -I.  -DLINUX
+  CFLAGS        :=  -O3 -I.  -DLINUX -Wno-incompatible-pointer-types
   LIBS  	:=  -L ../metis  -lmetis
   MSGLIBS	:=
 endif


### PR DESCRIPTION
Fix several bugs when compiling with Intel and GCC. 
To compile, set the FC env var to be the name of the Fortran compiler, e.g.

    FC=gfortran make -j4 all        # gcc, default if FC not specified
    FC=ifx make -j4 all              # intel
    FC=nvfortran make -j4 all        # nvidia

I'll update this on the README after this.

Currently works on my machine:
- GCC 14.2.1
- Intel 2025.1.1
- NVHPC 25.3
