### PR TITLE
added fallback behavior for nonstandard compiler ids

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,8 +59,14 @@ elif compiler_name == 'intel-llvm'
                         '-xHost',
                         '-132',
                         language: 'fortran')
-else
-  error(f'Compiler @compiler_name@ not supported.')
+else 
+  #Fallback for nonstandard names
+  flags = ['-ffixed-line-length-132', '-132', f'-r@sz@']
+  foreach flag : flags
+    if compiler.has_argument(flag)
+      add_project_arguments(flag, language: 'fortran')
+    endif
+  endforeach
 endif
 
 # Get hostname


### PR DESCRIPTION
Needed to build using non-oneAPI intel compilers on Frontera. I could hard-code add all the intel ids ('intel', 'intel-cl', 'intel-llvm-cl', etc.), but I figured this was more robust. 